### PR TITLE
Removed false information from router documentation

### DIFF
--- a/Getting-Started/Configuration-Guide.md
+++ b/Getting-Started/Configuration-Guide.md
@@ -454,15 +454,23 @@ If not set, the default value is the server version of the embedded MySQL/MariaD
 
 #### `weightby`
 
-The weightby parameter is used in conjunction with server parameters in order to control the load balancing applied in the router in use by the service. This allows varying weights to be applied to each server to create a non-uniform distribution of the load amongst the servers.
+The weightby parameter is used in conjunction with server parameters in order to
+control the load balancing applied in the router in use by the service. This
+allows varying weights to be applied to each server to create a non-uniform
+distribution of the load amongst the servers.
 
-An example of this might be to define a parameter for each server that represents the amount of resource available on the server, we could call this serversize. Every server should then have a serversize parameter set for the server.
+An example of this might be to define a parameter for each server that represents
+the amount of resource available on the server, we could call this serversize.
+Every server should then have a serversize parameter set for the server.
 
 ```
 serversize=10
 ```
 
-The service would then have the parameter weightby set. If there are 4 servers defined in the service, serverA, serverB, serverC and serverD, with the serversize set as shown in the table below, the connections would balanced using the percentages in this table.
+The service would then have the parameter `weightby=serversize`. If there are 4
+servers defined in the service (serverA, serverB, serverC and serverD) with the
+serversize set as shown in the table below, the connections would balanced
+using the percentages in this table.
 
  Server  |serversize|% connections
 ---------|----------|-------------
@@ -470,6 +478,46 @@ serverA  |   10     |     18%
 serverB  |   15     |     27%
 serverC  |   10     |     18%
 serverD  |   20     |     36%
+
+Here is an excerpt from an example configuration with the `serv_weight` parameter
+used as the weighting parameter.
+
+```
+[server1]
+type=server
+address=127.0.0.1
+port=3000
+protocol=MySQLBackend
+serv_weight=3
+
+[server2]
+type=server
+address=127.0.0.1
+port=3001
+protocol=MySQLBackend
+serv_weight=1
+
+[Read Service]
+type=service
+router=readconnroute
+servers=server1,server2
+weightby=serv_weight
+```
+
+With this configuration and a heavy query load, the server _server1_ will get
+most of the connections and about a third of the remaining queries are routed
+to the second server. With server weights, you can assign secondary servers
+that are only used when the primary server is under heavy load.
+
+Without the weightby parameter, each connection counts as a single connection.
+With a weighting parameter, a single connection received its weight from
+the server's own weighting parameter divided by the sum of all weighting
+parameters in all the configured servers.
+
+If we use the previous configuration as an example, the sum of the `serv_weight`
+parameter is 4. _Server1_ would receive a weight of `3/4=75%` and _server2_ would get
+`1/4=25%`. This means that _server1_ would get 75% of the connections and _server2_
+would get 25% of the connections.
 
 #### `auth_all_servers`
 

--- a/Routers/ReadConnRoute.md
+++ b/Routers/ReadConnRoute.md
@@ -10,32 +10,7 @@ The readconnroute router provides simple and lightweight load balancing across a
 
 Readconnroute router-specific settings are specified in the configuration file of MaxScale in its specific section. The section can be freely named but the name is used later as a reference from listener section.
 
-The configuration consists of mandatory and optional parameters.
-
-## Mandatory parameters
-
-**`type`** specifies the type of service. For readconnroute module the type is `router`:
-
-    type=router
-
-**`router`** specifies the router module to be used. For readconnroute the value is `readconnroute`:
-
-    router=readconnroute
-
-**`servers`** provides a list of servers, which the router will connect to:
-
-    servers=server1,server2,server3
-
-**NOTE: Each server on the list must have its own section in the configuration file where it is defined.**
-
-**`user`** is the username the router session uses for accessing backends in order to load the content of the `mysql.user` table (and `mysql.db` and database names as well) and optionally for creating, and using `maxscale_schema.replication_heartbeat` table.
-
-**`passwd`** specifies corresponding password for the user. Syntax for user and passwd is:
-
-```
-user=<username>
-passwd=<password>
-```
+For more details about the standard service parameters, refer to the [Configuration Guide](../Getting-Started/Configuration-Guide.md).
 
 ## Optional parameters
 

--- a/Routers/ReadConnRoute.md
+++ b/Routers/ReadConnRoute.md
@@ -12,38 +12,6 @@ Readconnroute router-specific settings are specified in the configuration file o
 
 For more details about the standard service parameters, refer to the [Configuration Guide](../Getting-Started/Configuration-Guide.md).
 
-## Optional parameters
-
-The **`weightby`** parameter defines the name of the value which is used to calculate the weights of the servers. Here is an example server configuration with the `serv_weight` parameter used as the weighting parameter.
-
-```
-[server1]
-type=server
-address=127.0.0.1
-port=3000
-protocol=MySQLBackend
-serv_weight=3
-
-[server2]
-type=server
-address=127.0.0.1
-port=3001
-protocol=MySQLBackend
-serv_weight=1
-
-[Read Service]
-type=service
-router=readconnroute
-servers=server1,server2
-weightby=serv_weight
-```
-
-With this configuration and a heavy query load, the server *server1* will get most of the connections and about a third of the remaining queries are routed to the second server. With server weights, you can assign secondary servers that are only used when the primary server is under heavy load.
-
-Without the weightby parameter, each connection counts as a single connection. With a weighting parameter, a single connection received its weight from the server's own weighting parameter divided by the sum of all weighting parameters in all the configured servers.
-
-If we use the previous configuration as an example, the sum of the `serv_weight` parameter is 4. Server1 would receive a weight of `3/4=75%` and server2 would get `1/4=25%`. This means that server1 would get 75% of the connections and server2 would get 25% of the connections.
-
 ## Router Options
 
 **`router_options`** can contain a list of valid server roles. These roles are used as the valid types of servers the router will form connections to when new sessions are created.
@@ -70,7 +38,7 @@ For a list of readconnroute limitations, please read the [Limitations](../About/
 
 The most common use for the readconnroute is to provide either a read or write port for an application. This provides a more lightweight routing solution than the more complex readwritesplit router but requires the application to be able to use distinct write and read ports.
 
-To configure a  read-only service that tolerates master failures, we first need to add a new section in to the configuration file.
+To configure a read-only service that tolerates master failures, we first need to add a new section in to the configuration file.
 
 ```
 [Read Service]
@@ -80,6 +48,6 @@ servers=slave1,slave2,slave3
 router_options=slave
 ```
 
-Here the `router_options`designates slaves as the only valid server type. With this configuration, the queries are load balanced across the slave servers.
+Here the `router_options` designates slaves as the only valid server type. With this configuration, the queries are load balanced across the slave servers.
 
 For more complex examples of the readconnroute router, take a look at the examples in the [Tutorials](../Tutorials) folder.

--- a/Routers/ReadWriteSplit.md
+++ b/Routers/ReadWriteSplit.md
@@ -47,16 +47,6 @@ When value all is used, queries reading session variables can be routed to any a
 
 In above-mentioned case the user-defined variable would only be updated in the master where query would be routed due to `INSERT` statement.
 
-### `weightby`
-
-This parameter defines the name of the value which is used to calculate the
-weights of the servers. The value should be the name of a parameter in the
-server definitions and it should exist in all the servers used by this router.
-For more information, see the description of the `weightby` parameter in
-the [Configuration Guide](../Getting-Started/Configuration-Guide.md).
-
-No weighting is used by default.
-
 ## Router options
 
 **`router_options`** may include multiple **readwritesplit**-specific options. All the options are parameter-value pairs. All parameters listed in this section must be configured as a value in `router_options`.

--- a/Routers/ReadWriteSplit.md
+++ b/Routers/ReadWriteSplit.md
@@ -12,41 +12,7 @@ The router is designed to be used with a traditional Master-Slave replication cl
 
 Readwritesplit router-specific settings are specified in the configuration file of MaxScale in its specific section. The section can be freely named but the name is used later as a reference from listener section.
 
-The configuration consists of mandatory and optional parameters.
-
-## Mandatory parameters
-
-### `type`
-
-**`type`** specifies the type of service. For **readwritesplit** module the type is `router`:
-
-    type=router
-
-### `router`
-
-**`router`** specifies the router module to be used. For **readwritesplit** the value is `readwritesplit`:
-
-    router=readwritesplit
-
-### `servers`
-
-**`servers`** provides a list of servers, which must include one master and available slaves:
-
-    servers=server1,server2,server3
-
-**NOTE: Each server on the list must have its own section in the configuration file where it is defined.**
-
-### `user`
-**`user`** is the username the router session uses for accessing backends in order to load the content of the `mysql.user` table (and `mysql.db` and database names as well) and optionally for creating, and using `maxscale_schema.replication_heartbeat` table.
-
-### `passwd`
-
-**`passwd`** specifies corresponding password for the user. Syntax for user and passwd is:
-
-```
-user=<username>
-passwd=<password>
-```
+For more details about the standard service parameters, refer to the [Configuration Guide](../Getting-Started/Configuration-Guide.md).
 
 ## Optional parameters
 

--- a/Routers/SchemaRouter.md
+++ b/Routers/SchemaRouter.md
@@ -42,16 +42,38 @@ GRANT SELECT,USAGE ON shard.* TO 'john'@'%';
 
 This would in effect allow the user 'john' to only see the database 'shard' on this server. Take notice that these grants are matched against MaxScale's hostname instead of the client's hostname. Only user authentication uses the client's hostname and all other grants use MaxScale's hostname.
 
-The schemarouter supports the following router options:
+## Optional parameters
 
-|option				|parameter	|description|
-|-------------------|-----------|-----------|
-|max_sescmd_history	|integer		|Set a limit on the number of session modifying commands a session can execute. This sets an effective cap on the memory consumption of the session.|
-|disable_sescmd_history|true, false|Disable the session command history. This will prevent growing memory consumption of a long-running session and allows pooled connections to MaxScale to be used. The drawback of this is the fact that if a server goes down, the session state will not be consistent anymore.|
-|refresh_databases|true, false|Enable database map refreshing mid-session. These are triggered by a failure to change the database i.e. `USE ...``queries.|
-|refresh_interval|float|The minimum interval between database map refreshes in seconds.|
-|ignore_databases|string|List of databases to ignore when checking for duplicate databases.|
-|ignore_databases_regex|string|Regular expression that is matched against database names when checking for duplicate databases.|
+### `ignore_databases`
+
+List of databases to ignore when checking for duplicate databases.
+
+### `ignore_databases_regex`
+
+Regular expression that is matched against database names when checking for duplicate databases.
+
+## Router options
+
+### `max_sescmd_history`
+
+Set a limit on the number of session modifying commands a session can execute.
+This sets an effective cap on the memory consumption of the session.
+
+### `disable_sescmd_history`
+
+Disable the session command history. This will prevent growing memory consumption
+of a long-running session and allows pooled connections to MaxScale to be used.
+The drawback of this is the fact that if a server goes down, the session state
+will not be consistent anymore.
+
+### `refresh_databases`
+
+Enable database map refreshing mid-session. These are triggered by a failure to
+change the database i.e. `USE ...``queries.
+
+### `refresh_interval`
+
+The minimum interval between database map refreshes in seconds.
 
 ## Limitations
 


### PR DESCRIPTION
The readwritesplit and readconnroute documentation listed the standard service
parameters and their explanations. These are already documented in the configuration
guide. In addition to this, they used wrong values for the `type` parameter.
